### PR TITLE
feat: add a fetcher.refresh-interval param

### DIFF
--- a/main.go
+++ b/main.go
@@ -596,6 +596,7 @@ func startFetcher(ctx context.Context, stores []e2wtypes.Store, monitor metrics.
 		memfetcher.WithLogLevel(util.LogLevel("fetcher")),
 		memfetcher.WithMonitor(fetcherMonitor),
 		memfetcher.WithStores(stores),
+		memfetcher.WithRefreshInterval(viper.GetDuration("fetcher.refresh-interval")),
 	)
 }
 

--- a/services/fetcher/mem/parameters.go
+++ b/services/fetcher/mem/parameters.go
@@ -14,6 +14,8 @@
 package mem
 
 import (
+	"time"
+
 	"github.com/attestantio/dirk/services/metrics"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -26,6 +28,8 @@ type parameters struct {
 	monitor   metrics.FetcherMonitor
 	encryptor e2wtypes.Encryptor
 	stores    []e2wtypes.Store
+
+	refreshInterval time.Duration
 }
 
 // Parameter is the interface for service parameters.
@@ -64,6 +68,13 @@ func WithEncryptor(encryptor e2wtypes.Encryptor) Parameter {
 func WithStores(stores []e2wtypes.Store) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.stores = stores
+	})
+}
+
+// WithRefreshInterval sets the refresh interval for new accounts
+func WithRefreshInterval(value time.Duration) Parameter {
+	return parameterFunc(func(p *parameters) {
+		p.refreshInterval = value
 	})
 }
 

--- a/services/fetcher/mem/service.go
+++ b/services/fetcher/mem/service.go
@@ -141,7 +141,7 @@ func (s *Service) repopulateCache(
 			}
 
 		case <-ctx.Done():
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
We are move keys from an external dirk to an internal dirk via presign URL. This patch periodically check for new keys and add them to memory. A new field in dirk.yaml:
```
fetcher:
  refresh-interval: 1m
```